### PR TITLE
Typo in ReportOutputFormat Enumeration

### DIFF
--- a/src/main/java/com/jaspersoft/jasperserver/jaxrs/client/apiadapters/reporting/ReportOutputFormat.java
+++ b/src/main/java/com/jaspersoft/jasperserver/jaxrs/client/apiadapters/reporting/ReportOutputFormat.java
@@ -24,5 +24,5 @@ package com.jaspersoft.jasperserver.jaxrs.client.apiadapters.reporting;
 public enum ReportOutputFormat {
 
     PDF, HTML, XLS, XLSX, RTF, CSV, XML, DOCX, ODT,
-    ODS, JPRINT
+    ODS, JRPRINT
 }


### PR DESCRIPTION
It should be JRPRINT, not JPRINT. This causes the client to fail when requesting a JasperPrint Object