### PR TITLE
Wrong MAVEN Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1931,7 +1931,7 @@ jrs-rest-client uses the implementation of JAX-RS API of version 2.0 and if your
         <dependency>
             <groupId>com.jaspersoft</groupId>
             <artifactId>jrs-rest-java-client</artifactId>
-            <version>6.1.4T</version>
+            <version>6.2.0</version>
         </dependency>
     </dependencies>
 
@@ -1940,7 +1940,7 @@ jrs-rest-client uses the implementation of JAX-RS API of version 2.0 and if your
         <repository>
             <id>jaspersoft-clients-snapshots</id>
             <name>Jaspersoft clients snapshots</name>
-            <url>http://jaspersoft.artifactoryonline.com/jaspersoft/jaspersoft-clients-snapshots</url>
+            <url>http://jaspersoft.artifactoryonline.com/jaspersoft/repo/</url>
         </repository>
 
     </repositories>


### PR DESCRIPTION
Hello,

i think the old repository URL is wrong.
Only the Version 5.6.0b-SNAPSHOT is avaliable at this location.

Please fix :)

Greets