### PR TITLE
Updating repository info to point to jfrog.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2244,16 +2244,16 @@ jrs-rest-client uses the implementation of JAX-RS API of version 2.0 and if your
         <dependency>
             <groupId>com.jaspersoft</groupId>
             <artifactId>jrs-rest-java-client</artifactId>
-            <version>6.1.4T</version>
+            <version>6.3.1</version>
         </dependency>
     </dependencies>
 
     <repositories>
-
+        
         <repository>
             <id>jaspersoft-clients-snapshots</id>
             <name>Jaspersoft clients snapshots</name>
-            <url>http://jaspersoft.artifactoryonline.com/jaspersoft/jaspersoft-clients-snapshots</url>
+            <url>https://jaspersoft.jfrog.io/jaspersoft/jaspersoft-clients-releases</url>
         </repository>
 
     </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,17 @@
         <tag>HEAD</tag>
     </scm>
 
-    <repositories>
+    <repositories>      
         <repository>
-            <id>jrs-ce-releases</id>
-            <name>JasperReports Server CE releases repository</name>
-            <url>http://jaspersoft.artifactoryonline.com/jaspersoft/jrs-ce-releases/</url>
+          <id>jaspersoft-clients-snapshots</id>
+          <name>Jaspersoft clients snapshots</name>
+          <url>https://jaspersoft.jfrog.io/jaspersoft/jaspersoft-clients-releases</url>
         </repository>
         <repository>
-            <id>opencast-public</id>
-            <url>http://repository.opencastproject.org/nexus/content/repositories/public/</url>
-        </repository>
+          <id>central</id>
+          <name>jaspersoft-releases</name>
+          <url>https://jaspersoft.jfrog.io/jaspersoft/jrs-ce-releases</url>
+        </repository>        
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
Hi, 

I tried to build this project the other day, and I ran into some issues downloading dependencies. I dug into it, and I noticed that the repository information in pom.xml was out of date - it was pointing to jaspersoft.artifactoryonline.com. It appears that this repo has been migrated to jaspersoft.jfrog.io, so I've gone ahead and updated the pom to reflect this. 

Additionally, the dependency info in the README was also out of date. I've updated it to reflect the latest published artifact in jfrog, and updated the repository to use jfrog as well. 

Thanks for your work on this library, it does provide quite a nice interface to JasperServer.
